### PR TITLE
Be more flexible in separating ingredient name and preparation

### DIFF
--- a/src/ingredient.test.ts
+++ b/src/ingredient.test.ts
@@ -27,6 +27,34 @@ describe.each([
     'garlic -- minced (optional)',
     [undefined, undefined, undefined, 'garlic', 'minced', true]
   ],
+  [
+    'garlic — minced (optional)',
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
+  ],
+  [
+    'garlic – minced (optional)',
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
+  ],
+  [
+    'garlic; minced (optional)',
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
+  ],
+  [
+    'garlic;minced (optional)',
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
+  ],
+  [
+    'garlic - minced (optional)',
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
+  ],
+  [
+    'garlic - minced - finely (optional)',
+    [undefined, undefined, undefined, 'garlic', 'minced - finely', true]
+  ],
+  [
+    'garlic-minced (optional)',
+    [undefined, undefined, undefined, 'garlic-minced', undefined, true]
+  ],
   ['1⅔c garlic', [5, 3, 'c', 'garlic', undefined, false]],
   ['1 ⅔ c garlic', [5, 3, 'c', 'garlic', undefined, false]],
   ['1⅔ c garlic', [5, 3, 'c', 'garlic', undefined, false]],

--- a/src/ingredient.ts
+++ b/src/ingredient.ts
@@ -83,13 +83,13 @@ function isOptional(s?: string): [string, boolean] {
 
 // parse a string into an ingredient name, optionally followed by a preparation
 function parsePrep(s?: string): [string, string | undefined] {
-  const prepSep = '--'
   if (!s) {
     return ['', undefined]
   }
-  const parts = s.split(prepSep)
-  if (parts.length < 2) {
+  const parts = s.match(/(.+)(?:--|;|–|—| - )(.+)/)
+  if (!parts) {
     return [_.trim(s), undefined]
   }
-  return [_.trim(_.head(parts)), _.trim(_.tail(parts).join(prepSep))]
+  const [name, prep] = _.tail(parts)
+  return [_.trim(name), _.trim(prep)]
 }


### PR DESCRIPTION
There are two goals here. First, it turns out that it can be hard to
type `--` on some systems. For example, on iOS, typing `--` will get
autocorrected to an em dash. By accepting an em dash as a separator, we
make it much more feasible to actually edit recipes on mobile devices.

Second, we can potentially parse out more different ways the preparation
note might be separated when importing recipes from external sources.