### PR TITLE
Handle multiple amounts and units

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,3 +2,4 @@
 
 semi: false
 singleQuote: true
+trailingComma: 'none'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/jest": "24.0.11",
+    "@types/node": "13.13.0",
     "jest": "24.7.1",
     "ts-jest": "24.0.2",
     "typescript": "3.4.5"

--- a/src/ingredient.test.ts
+++ b/src/ingredient.test.ts
@@ -3,67 +3,86 @@ import { parseIngredient } from './index'
 describe.each([
   [
     '2 tablespoons fresh lemon juice',
-    [2, 1, 'tbsp', 'fresh lemon juice', undefined, false]
+    [2, 1, 'tbsp', 'fresh lemon juice', undefined, false],
   ],
   [
     '3 garlic cloves, roughly chopped',
-    [3, 1, undefined, 'garlic cloves, roughly chopped', undefined, false]
+    [3, 1, undefined, 'garlic cloves, roughly chopped', undefined, false],
   ],
   ['1 15-ounce can', [1, 1, undefined, '15-ounce can', undefined, false]],
   ['1/4 cup olive oil', [1, 4, 'c', 'olive oil', undefined, false]],
   [
     'salt and pepper',
-    [undefined, undefined, undefined, 'salt and pepper', undefined, false]
+    [undefined, undefined, undefined, 'salt and pepper', undefined, false],
   ],
   [
     '    1/2    tsp   garlic      --      minced     (optional)     ',
-    [1, 2, 'tsp', 'garlic', 'minced', true]
+    [1, 2, 'tsp', 'garlic', 'minced', true],
   ],
   [
     'salt (optional)',
-    [undefined, undefined, undefined, 'salt', undefined, true]
+    [undefined, undefined, undefined, 'salt', undefined, true],
   ],
   [
     'garlic -- minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true]
+    [undefined, undefined, undefined, 'garlic', 'minced', true],
   ],
   [
     'garlic — minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true]
+    [undefined, undefined, undefined, 'garlic', 'minced', true],
   ],
   [
     'garlic – minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true]
+    [undefined, undefined, undefined, 'garlic', 'minced', true],
   ],
   [
     'garlic; minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true]
+    [undefined, undefined, undefined, 'garlic', 'minced', true],
   ],
   [
     'garlic;minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true]
+    [undefined, undefined, undefined, 'garlic', 'minced', true],
   ],
   [
     'garlic - minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true]
+    [undefined, undefined, undefined, 'garlic', 'minced', true],
   ],
   [
     'garlic - minced - finely (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced - finely', true]
+    [undefined, undefined, undefined, 'garlic', 'minced - finely', true],
   ],
   [
     'garlic-minced (optional)',
-    [undefined, undefined, undefined, 'garlic-minced', undefined, true]
+    [undefined, undefined, undefined, 'garlic-minced', undefined, true],
   ],
   ['1⅔c garlic', [5, 3, 'c', 'garlic', undefined, false]],
   ['1 ⅔ c garlic', [5, 3, 'c', 'garlic', undefined, false]],
   ['1⅔ c garlic', [5, 3, 'c', 'garlic', undefined, false]],
   [
     '5.5oz tomato paste, sliced',
-    [11, 2, 'oz', 'tomato paste, sliced', undefined, false]
+    [11, 2, 'oz', 'tomato paste, sliced', undefined, false],
+  ],
+  [
+    '250g/9oz long grain or basmati rice',
+    [250, 1, 'g', 'long grain or basmati rice', undefined, false],
+  ],
+  [
+    '600ml/20fl oz chicken stock',
+    [600, 1, 'ml', 'chicken stock', undefined, false],
+  ],
+  [
+    '500g/1lb 2oz skinless, boneless chicken thighs, cut into bite-sized pieces',
+    [
+      500,
+      1,
+      'g',
+      'skinless, boneless chicken thighs, cut into bite-sized pieces',
+      undefined,
+      false,
+    ],
   ],
   ['', [undefined, undefined, undefined, '', undefined, false]],
-  [undefined, [undefined, undefined, undefined, '', undefined, false]]
+  [undefined, [undefined, undefined, undefined, '', undefined, false]],
 ])(
   'parseIngredient(%s)',
   (

--- a/src/ingredient.test.ts
+++ b/src/ingredient.test.ts
@@ -3,72 +3,72 @@ import { parseIngredient } from './index'
 describe.each([
   [
     '2 tablespoons fresh lemon juice',
-    [2, 1, 'tbsp', 'fresh lemon juice', undefined, false],
+    [2, 1, 'tbsp', 'fresh lemon juice', undefined, false]
   ],
   [
     '3 garlic cloves, roughly chopped',
-    [3, 1, undefined, 'garlic cloves, roughly chopped', undefined, false],
+    [3, 1, undefined, 'garlic cloves, roughly chopped', undefined, false]
   ],
   ['1 15-ounce can', [1, 1, undefined, '15-ounce can', undefined, false]],
   ['1/4 cup olive oil', [1, 4, 'c', 'olive oil', undefined, false]],
   [
     'salt and pepper',
-    [undefined, undefined, undefined, 'salt and pepper', undefined, false],
+    [undefined, undefined, undefined, 'salt and pepper', undefined, false]
   ],
   [
     '    1/2    tsp   garlic      --      minced     (optional)     ',
-    [1, 2, 'tsp', 'garlic', 'minced', true],
+    [1, 2, 'tsp', 'garlic', 'minced', true]
   ],
   [
     'salt (optional)',
-    [undefined, undefined, undefined, 'salt', undefined, true],
+    [undefined, undefined, undefined, 'salt', undefined, true]
   ],
   [
     'garlic -- minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true],
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
   ],
   [
     'garlic — minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true],
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
   ],
   [
     'garlic – minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true],
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
   ],
   [
     'garlic; minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true],
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
   ],
   [
     'garlic;minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true],
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
   ],
   [
     'garlic - minced (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced', true],
+    [undefined, undefined, undefined, 'garlic', 'minced', true]
   ],
   [
     'garlic - minced - finely (optional)',
-    [undefined, undefined, undefined, 'garlic', 'minced - finely', true],
+    [undefined, undefined, undefined, 'garlic', 'minced - finely', true]
   ],
   [
     'garlic-minced (optional)',
-    [undefined, undefined, undefined, 'garlic-minced', undefined, true],
+    [undefined, undefined, undefined, 'garlic-minced', undefined, true]
   ],
   ['1⅔c garlic', [5, 3, 'c', 'garlic', undefined, false]],
   ['1 ⅔ c garlic', [5, 3, 'c', 'garlic', undefined, false]],
   ['1⅔ c garlic', [5, 3, 'c', 'garlic', undefined, false]],
   [
     '5.5oz tomato paste, sliced',
-    [11, 2, 'oz', 'tomato paste, sliced', undefined, false],
+    [11, 2, 'oz', 'tomato paste, sliced', undefined, false]
   ],
   [
     '250g/9oz long grain or basmati rice',
-    [250, 1, 'g', 'long grain or basmati rice', undefined, false],
+    [250, 1, 'g', 'long grain or basmati rice', undefined, false]
   ],
   [
     '600ml/20fl oz chicken stock',
-    [600, 1, 'ml', 'chicken stock', undefined, false],
+    [600, 1, 'ml', 'oz chicken stock', undefined, false]
   ],
   [
     '500g/1lb 2oz skinless, boneless chicken thighs, cut into bite-sized pieces',
@@ -76,13 +76,13 @@ describe.each([
       500,
       1,
       'g',
-      'skinless, boneless chicken thighs, cut into bite-sized pieces',
+      '2oz skinless, boneless chicken thighs, cut into bite-sized pieces',
       undefined,
-      false,
-    ],
+      false
+    ]
   ],
   ['', [undefined, undefined, undefined, '', undefined, false]],
-  [undefined, [undefined, undefined, undefined, '', undefined, false]],
+  [undefined, [undefined, undefined, undefined, '', undefined, false]]
 ])(
   'parseIngredient(%s)',
   (

--- a/src/ingredient.ts
+++ b/src/ingredient.ts
@@ -40,38 +40,22 @@ export const parseIngredient = (s?: string): Ingredient | undefined => {
     quantity_denominator: undefined,
     preparation: undefined,
     optional: false,
-    unit: undefined,
+    unit: undefined
   }
   if (!s) {
     return ing
   }
   s = _.trim(s)
-
-  // While we are parsing valid amount/unit combos, greedy
-  // consume them, but only keep the first
-  let amount
-  let unit
-  let latestAmount, amountRest
-  let latestUnit
-  do {
-    ;[latestAmount, amountRest] = matchNumber(s)
-    if (!amount) {
-      amount = latestAmount
-    }
-    s = _.trim(amountRest)
-    const [maybeUnit, ...rest] = s.split(/\s/)
-    latestUnit = parseUnit(maybeUnit)
-    if (!unit) {
-      unit = latestUnit
-    }
-    if (latestUnit) {
-      s = rest.join(' ')
-    }
-  } while ((latestAmount.n && latestAmount.d) || latestUnit)
-  ing.quantity_numerator = amount.n
-  ing.quantity_denominator = amount.d
-  ing.unit = unit
-  //
+  const [num, numRest] = matchNumber(s)
+  ing.quantity_numerator = num.n
+  ing.quantity_denominator = num.d
+  s = _.trim(numRest)
+  const [maybeUnit, ...rest] = s.split(/\s/)
+  const unit = parseUnit(maybeUnit)
+  if (unit) {
+    ing.unit = unit
+    s = rest.join(' ')
+  }
   const [str, optional] = isOptional(s)
   ing.optional = optional
   let [name, prep] = parsePrep(str)

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -1,3 +1,5 @@
+import { first, includes } from 'lodash'
+
 export type Unit =
   | 'g'
   | 'mg'
@@ -23,6 +25,14 @@ export const parseUnit = (s?: string): Unit | undefined => {
   if (s === 'T') {
     return 'tbsp'
   }
+
+  // Some sites have amounts listed in two units, like:
+  // 500g/1lb or 200g/7oz
+  // If the `/` is present, break the unit on that and parse the first unit.
+  if (includes(s, '/')) {
+    s = first(s.split('/'))
+  }
+
   const unit = s.toLowerCase()
   switch (unit) {
     case 'oz':

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/node@13.13.0":
+  version "13.13.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.0.tgz#30d2d09f623fe32cde9cb582c7a6eda2788ce4a8"
+  integrity sha512-WE4IOAC6r/yBZss1oQGM5zs2D7RuKR6Q+w+X2SouPofnWn+LbCqClRyhO3ZE7Ix8nmFgo/oVuuE01cJT2XB13A==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
Add in better, but not perfect, handling for multiple amounts in an ingredient
line. 

### Notable Failures
This doesn't handle ingredients and amounts that have a space in them, which
the BBC website uses quite a bit:

```
600ml/20fl oz
```

This PR will correct remove read the `600ml` and remove the `20fl` from the
parsing, but it will not remove the `oz`. Some playing around with trying to
also remove the oz resulted in regressions in other tests, so I decided to not
pursue this further for now. I think a better solution will be a combination of
amount/unit parsing that is greedier, but also smarter.

I'm tracking this new issue in #6.

Resolve #4